### PR TITLE
Fixed Makefile not linking.

### DIFF
--- a/C/Makefile
+++ b/C/Makefile
@@ -1,5 +1,5 @@
 all: Dupechecker.c Scraper.c
-	gcc Dupechecker.c -o Dupechecker -lssl
+	gcc Dupechecker.c -o Dupechecker -lssl -L/usr/lib -lcrypto
 	gcc Scraper.c -o Scraper -lcurl -g -Wall
 	chmod +x Dupechecker Scraper
 


### PR DESCRIPTION
The Makefile was not linking due to a missing option to gcc. These parameters were the -lcrypto and the -L/usr/lib options. Adding these options allowed it to link properly.